### PR TITLE
Limpiar las conexiones de la BBDD

### DIFF
--- a/gatovid/app.py
+++ b/gatovid/app.py
@@ -82,6 +82,7 @@ app = create_app()
 app.register_blueprint(api.data.mod)
 # app.register_blueprint(api.game.mod)
 
+
 @app.teardown_appcontext
 def shutdown_session(exception=None):
     """
@@ -89,6 +90,7 @@ def shutdown_session(exception=None):
     colgadas sin usarse (Ref: https://stackoverflow.com/a/53715116).
     """
     db.session.remove()
+
 
 @app.route("/")
 def index():

--- a/gatovid/app.py
+++ b/gatovid/app.py
@@ -82,6 +82,13 @@ app = create_app()
 app.register_blueprint(api.data.mod)
 # app.register_blueprint(api.game.mod)
 
+@app.teardown_appcontext
+def shutdown_session(exception=None):
+    """
+    Limpiar automáticamente las conexiones de SQLAlchemy para que no se queden
+    colgadas sin usarse (Ref: https://stackoverflow.com/a/53715116).
+    """
+    db.session.remove()
 
 @app.route("/")
 def index():


### PR DESCRIPTION
SQLAlchemy tiene un límite de conexiones concurrentes a la base de datos. Si no se limpian correctamente las sesiones de SQLAlchemy, se mantiene la conexión sin usar. Si esto se repite varias veces, se puede alcanzar el límite de conexiones simultáneas y, por lo tanto, dejar de funcionar el backend.