### PR TITLE
CI para la documentación

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,3 +54,17 @@ jobs:
         run: python -m black . --check
       - name: Run isort
         run: python -m isort . --check
+
+  # Asegura que los docs compilen correctamente también
+  python-docs:
+    name: Python docs
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: pip install -e .[docs]
+      - name: Attempt to compile
+        # With warnings as errors
+        run: cd docs && make html SPHINXOPTS="-W"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
       - name: Set up dependencies
         run: pip install -e .[docs]
       - name: Attempt to compile

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -66,4 +66,4 @@ html_theme = "furo"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []


### PR DESCRIPTION
Con esto nos aseguramos que la documentación compila correctamente en el CI, dado que readthedocs no parece mostrar ningún mensaje aquí en GitHub sobre los deploys.