### PR TITLE
None en `modify_user` no falla

### DIFF
--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -485,6 +485,9 @@ class UserTest(GatovidTestClient):
                 },
                 True,
             ),
+            # Campos nulos
+            ({"name": self.existing_user["name"], "password": None}, False),
+            ({"name": None, "password": self.existing_user["password"]}, False),
         ]
 
         token_resp = self.request_token(self.existing_user)


### PR DESCRIPTION
Probando la web he visto que, si no se introducen los campos de contraseña, se hace una petición con nulos al endpoint `modify_user`.

He hecho unos tests que prueban que no funciona como debería.