### PR TITLE
Arregla threading

### DIFF
--- a/gatovid/api/game/match.py
+++ b/gatovid/api/game/match.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 from gatovid.exts import db, socket
 from gatovid.game import Action, Game, GameLogicException, GameUpdate
 from gatovid.models import User
-from gatovid.util import get_logger
+from gatovid.util import Timer, get_logger
 
 logger = get_logger(__name__)
 matches = dict()
@@ -281,7 +281,7 @@ class PublicMatch(Match):
 
         # Timer para empezar la partida si en TIME_UNTIL_START segundos no se
         # han conectado todos los jugadores.
-        self.start_timer = threading.Timer(TIME_UNTIL_START, self.start_check)
+        self.start_timer = Timer(TIME_UNTIL_START, self.start_check)
 
     def start(self):
         # Cancelamos el timer si sigue
@@ -351,9 +351,7 @@ class MatchManager:
             # En caso contrario, si se ha llegado al mínimo de usuarios se
             # inicia el timer.
             if len(self.users_waiting) == MIN_MATCH_USERS:
-                self._public_timer = threading.Timer(
-                    TIME_UNTIL_START, self.matchmaking_check
-                )
+                self._public_timer = Timer(TIME_UNTIL_START, self.matchmaking_check)
                 self._public_timer.start()
 
     def matchmaking_check(self):

--- a/gatovid/game/__init__.py
+++ b/gatovid/game/__init__.py
@@ -15,7 +15,7 @@ from gatovid.game.cards import DECK, Card
 # Exportamos GameLogicException
 from gatovid.game.common import GameLogicException, GameUpdate
 from gatovid.models import User
-from gatovid.util import PausableTimer, get_logger
+from gatovid.util import Timer, get_logger
 
 logger = get_logger(__name__)
 
@@ -105,6 +105,15 @@ class Game:
         # excepto seguir descartando o pasar el turno.
         self.discarding = False
 
+    def __del__(self) -> None:
+        """
+        Destructor que termina la partida si no se ha hecho ya anteriormente.
+        """
+
+        print("ALLELUYA")
+        if not self._finished:
+            self.finish()
+
     def start(self) -> GameUpdate:
         """
         Inicializa la baraja, la reordena de forma aleatoria, y reparte 3 cartas
@@ -163,7 +172,7 @@ class Game:
                 self._turn_timer.pause()
 
                 # Iniciamos un timer
-                self._pause_timer = threading.Timer(TIME_UNTIL_RESUME, resume_callback)
+                self._pause_timer = Timer(TIME_UNTIL_RESUME, resume_callback)
                 self._pause_timer.start()
 
                 logger.info(f"Game paused by {paused_by}")
@@ -355,7 +364,7 @@ class Game:
         if self._turn_timer is not None:
             self._turn_timer.cancel()
 
-        self._turn_timer = PausableTimer(TIME_TURN_END, self._timer_end_turn)
+        self._turn_timer = Timer(TIME_TURN_END, self._timer_end_turn)
         self._turn_timer.start()
 
     def turn_player(self) -> Player:

--- a/gatovid/game/__init__.py
+++ b/gatovid/game/__init__.py
@@ -110,7 +110,6 @@ class Game:
         Destructor que termina la partida si no se ha hecho ya anteriormente.
         """
 
-        print("ALLELUYA")
         if not self._finished:
             self.finish()
 

--- a/gatovid/util.py
+++ b/gatovid/util.py
@@ -68,14 +68,20 @@ def get_logger(name: str) -> logging.Logger:
     return logger
 
 
-class PausableTimer:
+class Timer:
     """
     Wrapper sobre threading.Timer que permite pausar y continuar la ejecución
     del temporizador.
+
+    También establece por defecto que sea un thread de tipo deamon, significando
+    que al acabar el programa también terminarán los threads pendientes.
+
+    Debería usarse siempre esta clase en vez de la original en threading.Timer.
     """
 
     def __init__(self, interval: float, *args, **kwargs) -> None:
         self._timer = threading.Timer(interval, *args, **kwargs)
+        self._timer.setDaemon(True)
         self._interval = timedelta(seconds=interval)
         self._args = args
         self._kwargs = kwargs


### PR DESCRIPTION
Te explico:

El problema de que se quedara atascado el programa en los tests y no acabase nunca se debía a que, al fallar el test, no se llamaba nunca a `Game.finish`. Por tanto, los timers seguían ejecutándose de fondo, y el proceso no terminaba.

Esto lo he arreglado de dos formas:

* Usando siempre `gatovid.util.Timer`, que ahora establece el timer interno siempre como uno de tipo deamon. Si se indica `setDaemon(True)`, el thread acabará con el programa principal y no se quedará pillado.
* Implementando un destructor en `Game` que termine la partida si no se ha hecho previamente (esto no es realmente necesario con lo anterior pero evitamos posibles leaks)

Después de mergear esto los tests de `game-update` ya deberían pasar y lo puedes mergear en ese caso.