### PR TITLE
Fix rejoin (ahora si)

### DIFF
--- a/gatovid/api/game/__init__.py
+++ b/gatovid/api/game/__init__.py
@@ -252,7 +252,7 @@ def join(game_code):
         logger.info(f"User {session['user']} reconnecting to game")
         # Actualizamos el SID del usuario y el nombre si lo ha cambiado
         try:
-            match.update_user()
+            match.update_user(session["user"])
         except GameLogicException as e:
             # NOTE: No debería darse este error por la condición de
             # can_rejoin, pero por curarnos en salud.

--- a/gatovid/api/game/__init__.py
+++ b/gatovid/api/game/__init__.py
@@ -250,6 +250,13 @@ def join(game_code):
     can_rejoin, initial_update = match.check_rejoin(session["user"])
     if can_rejoin:
         logger.info(f"User {session['user']} reconnecting to game")
+        # Actualizamos el SID del usuario y el nombre si lo ha cambiado
+        try:
+            match.update_user()
+        except GameLogicException as e:
+            # NOTE: No debería darse este error por la condición de
+            # can_rejoin, pero por curarnos en salud.
+            return {"error": str(e)}
         emit("start_game", room=session["user"].sid)
         emit("game_update", initial_update, room=session["user"].sid)
         return

--- a/gatovid/api/game/match.py
+++ b/gatovid/api/game/match.py
@@ -288,6 +288,22 @@ class Match:
 
         self.users.append(user)
 
+    def update_user(self, user: User) -> None:
+        """
+        Actualiza la información del usuario, como el SID (cambia en
+        la reconexión) o el nombre si lo ha modificado antes de
+        reconectarse.
+
+        Puede darse una excepción el usuario no se encuentra en la partida.
+        """
+
+        for (i, u) in enumerate(self.users):
+            if u == user:
+                self.users[i] = user
+                return
+
+        raise GameLogicException("El usuario no está en la partida")
+
     def remove_user(self, user: User) -> None:
         try:
             self.users.remove(user)


### PR DESCRIPTION
Basicamente no se envian mensajes a los usuarios porque al reconectarse, no se reconectan con el mismo SID (la conexion de websockets cambia). Los objetos de flask-sqlalchemy son lazy-loaded y guardan una copia (que no se actualiza automáticamente); eso hace que, cuando un jugador se reconecta, tuviera el SID anterior en su objeto `User` de `self.users` en `Match`.